### PR TITLE
Add theme.json support

### DIFF
--- a/src/superlist-item/block.json
+++ b/src/superlist-item/block.json
@@ -15,7 +15,8 @@
 		"color": {
 			"background": true,
 			"gradients": true,
-			"text": true
+			"text": true,
+			"link": true
 		},
 		"spacing": {
 			"margin": true,

--- a/src/superlist-item/style.scss
+++ b/src/superlist-item/style.scss
@@ -4,3 +4,43 @@
  *
  * Replace them with your own styles or remove the file completely.
  */
+.wp-block-createwithrani-superlist-item {
+	--textColor: var(--wp--custom--superlist-item--color--text, inherit);
+	--linkColor: var(--wp--custom--superlist-item--color--link, inherit);
+	--backgroundColor: var(
+		--wp--custom--superlist-item--color--background-color,
+		inherit
+	);
+	--fontSize: var(--wp--custom--superlist-item--typography--font-size, inherit);
+	--fontFamily: var(
+		--wp--custom--superlist-item--typography--font-family,
+		inherit
+	);
+	--lineHeight: var(
+		--wp--custom--superlist-item--typography--line-height,
+		inherit
+	);
+	--textTransform: var(
+		--wp--custom--superlist-item--typography--text-transform,
+		inherit
+	);
+	--fontWeight: var(
+		--wp--custom--superlist-item--typography--font-weight,
+		inherit
+	);
+
+	--margin: var(--wp--custom--superlist-item--spacing--margin, inherit);
+	--padding: var(--wp--custom--superlist-item--spacing--padding, inherit);
+	color: var(--textColor);
+	background-color: var(--backgroundColor);
+	font-size: var(--fontSize);
+	font-family: var(--fontFamily);
+	font-weight: var(--fontWeight);
+	line-height: var(--lineHeight);
+	text-transform: var(--textTransform);
+	margin: var(--margin);
+	padding: var(--padding);
+	a {
+		color: var(--linkColor);
+	}
+}

--- a/src/superlist/block.json
+++ b/src/superlist/block.json
@@ -16,8 +16,7 @@
 			"default": "vertical"
 		},
 		"itemWidth": {
-			"type": "string",
-			"default": "350px"
+			"type": "string"
 		},
 		"verticalAlignment": {
 			"type": "string"
@@ -30,7 +29,8 @@
 		"color": {
 			"background": true,
 			"gradients": true,
-			"text": true
+			"text": true,
+			"link": true
 		},
 		"spacing": {
 			"margin": true,

--- a/src/superlist/block.json
+++ b/src/superlist/block.json
@@ -12,8 +12,7 @@
 			"default": "ul"
 		},
 		"orientation": {
-			"type": "string",
-			"default": "vertical"
+			"type": "string"
 		},
 		"itemWidth": {
 			"type": "string"

--- a/src/superlist/edit.js
+++ b/src/superlist/edit.js
@@ -64,21 +64,37 @@ const LIST_TEMPLATE = [
 export default function Edit(props) {
 	const { attributes, setAttributes } = props;
 	const { listStyle, orientation, itemWidth, verticalAlignment } = attributes;
+
+	// check if theme.json has set a preferred list orientation
+	const themeListOrientation = useSetting(
+		"custom.superlist-block.listSettings.orientation"
+	);
+
+	// set the default list orientation to theme.json preference but if there's no theme.json preference, set it to vertical
+	const defaultListOrientation =
+		undefined === themeListOrientation ? "vertical" : themeListOrientation;
+
+	// set up a state variable for list orientation, use the orientation attribute if it is set, otherwise  use the smart default
+	const [listOrientation, setListOrientation] = useState(
+		undefined !== orientation ? orientation : defaultListOrientation
+	);
+
 	const [width, setWidth] = useState(itemWidth);
+
 	const subItemWidth = {
-		"--wp--custom--superlist-block--item--width": width,
+		"--wp--custom--superlist-block--list-settings--width": width,
 	};
 	const blockProps = useBlockProps({
-		className: classnames(listStyle, orientation, {
+		className: classnames(listStyle, listOrientation, {
 			[`is-vertically-aligned-${verticalAlignment}`]: verticalAlignment,
 		}),
-		style: "horizontal" === orientation ? subItemWidth : {},
+		style: "horizontal" === listOrientation ? subItemWidth : {},
 	});
 
 	const innerBlockProps = useInnerBlocksProps(blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		template: LIST_TEMPLATE,
-		orientation: `${orientation}`,
+		orientation: `${listOrientation}`,
 		templateInsertUpdateSelection: true,
 	});
 	function switchStyle(style) {
@@ -90,6 +106,10 @@ export default function Edit(props) {
 	}
 	function updateAlignment(verticalAlignment) {
 		setAttributes({ verticalAlignment: verticalAlignment });
+	}
+	function updateOrientation(orientation) {
+		setListOrientation(orientation);
+		setAttributes({ orientation: orientation });
 	}
 	const ListContainer = "none" !== listStyle ? listStyle : "div";
 	return (
@@ -105,8 +125,8 @@ export default function Edit(props) {
 					placement="toolbar"
 				/>
 				<Orientation
-					orientation={orientation}
-					setAttributes={setAttributes}
+					listOrientation={listOrientation}
+					updateOrientation={updateOrientation}
 					placement="toolbar"
 				/>
 			</BlockControls>
@@ -115,7 +135,7 @@ export default function Edit(props) {
 					initialOpen={true}
 					title={__("List Settings", "superlist-block")}
 				>
-					{orientation === "horizontal" && (
+					{listOrientation === "horizontal" && (
 						<PanelRow>
 							<UnitControl
 								label={__("List-item max-width", "superlist-block")}
@@ -134,8 +154,8 @@ export default function Edit(props) {
 					</PanelRow>
 					<PanelRow>
 						<Orientation
-							orientation={orientation}
-							setAttributes={setAttributes}
+							listOrientation={listOrientation}
+							updateOrientation={updateOrientation}
 							placement="inspector"
 						/>
 					</PanelRow>

--- a/src/superlist/edit.js
+++ b/src/superlist/edit.js
@@ -66,7 +66,7 @@ export default function Edit(props) {
 	const { listStyle, orientation, itemWidth, verticalAlignment } = attributes;
 	const [width, setWidth] = useState(itemWidth);
 	const subItemWidth = {
-		gridTemplateColumns: `repeat(auto-fill, minmax(${width}, 1fr))`,
+		"--wp--custom--superlist-block--item--width": width,
 	};
 	const blockProps = useBlockProps({
 		className: classnames(listStyle, orientation, {

--- a/src/superlist/editor.scss
+++ b/src/superlist/editor.scss
@@ -7,7 +7,6 @@
 .editor-styles-wrapper .wp-block-createwithrani-superlist-block {
 	&.horizontal {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
 		li {
 			margin: 0;
 		}

--- a/src/superlist/orientation.js
+++ b/src/superlist/orientation.js
@@ -1,38 +1,50 @@
-import { __ } from '@wordpress/i18n';
-import { ToolbarButton, Button } from '@wordpress/components';
-import { arrowRight, arrowDown } from '@wordpress/icons';
+import { __ } from "@wordpress/i18n";
+import { ToolbarButton, Button } from "@wordpress/components";
+import { arrowRight, arrowDown } from "@wordpress/icons";
 
-export const Orientation = ({ orientation, setAttributes, placement }) => {
-	return 'toolbar' === placement ? (
+export const Orientation = ({
+	listOrientation,
+	placement,
+	updateOrientation,
+}) => {
+	return "toolbar" === placement ? (
 		<>
 			<ToolbarButton
 				icon={arrowRight}
-				label={__('Horizontal orientation', 'superlist-block')}
-				onClick={() => setAttributes({ orientation: 'horizontal' })}
-				isActive={orientation === 'horizontal'}
+				label={__("Horizontal orientation", "superlist-block")}
+				onClick={() => {
+					updateOrientation("horizontal");
+				}}
+				isActive={listOrientation === "horizontal"}
 			/>
 			<ToolbarButton
 				icon={arrowDown}
-				label={__('Vertical Orientation', 'superlist-block')}
-				onClick={() => setAttributes({ orientation: 'vertical' })}
-				isActive={orientation === 'vertical'}
+				label={__("Vertical Orientation", "superlist-block")}
+				onClick={() => {
+					updateOrientation("vertical");
+				}}
+				isActive={listOrientation === "vertical"}
 			/>
 		</>
 	) : (
 		<fieldset className="block-editor-hooks__flex-layout-justification-controls">
-			<legend>{__('Orientation')}</legend>
+			<legend>{__("Orientation")}</legend>
 			<div>
 				<Button
 					icon={arrowRight}
-					label={__('Horizontal orientation')}
-					onClick={() => setAttributes({ orientation: 'horizontal' })}
-					isPressed={orientation === 'horizontal'}
+					label={__("Horizontal orientation")}
+					onClick={() => {
+						updateOrientation("horizontal");
+					}}
+					isPressed={listOrientation === "horizontal"}
 				/>
 				<Button
 					icon={arrowDown}
-					label={__('Vertical Orientation')}
-					onClick={() => setAttributes({ orientation: 'vertical' })}
-					isPressed={orientation === 'vertical'}
+					label={__("Vertical Orientation")}
+					onClick={() => {
+						updateOrientation("vertical");
+					}}
+					isPressed={listOrientation === "vertical"}
 				/>
 			</div>
 		</fieldset>

--- a/src/superlist/style.scss
+++ b/src/superlist/style.scss
@@ -4,12 +4,13 @@
  *
  * Replace them with your own styles or remove the file completely.
  */
-
 .wp-block-createwithrani-superlist-block {
+	--listItemWidth: var(--wp--custom--superlist-block--item--width, 250px);
 	&.horizontal {
 		display: grid;
 		gap: 2rem;
 		grid-template-rows: auto;
+		grid-template-columns: repeat(auto-fill, minmax(var(--listItemWidth), 1fr));
 	}
 	&.none {
 		list-style: none;

--- a/src/superlist/style.scss
+++ b/src/superlist/style.scss
@@ -6,6 +6,47 @@
  */
 .wp-block-createwithrani-superlist-block {
 	--listItemWidth: var(--wp--custom--superlist-block--item--width, 250px);
+	--textColor: var(--wp--custom--superlist-block--color--text, inherit);
+	--linkColor: var(--wp--custom--superlist-block--color--link, inherit);
+	--backgroundColor: var(
+		--wp--custom--superlist-block--color--background-color,
+		inherit
+	);
+	--fontSize: var(
+		--wp--custom--superlist-block--typography--font-size,
+		inherit
+	);
+	--fontFamily: var(
+		--wp--custom--superlist-block--typography--font-family,
+		inherit
+	);
+	--lineHeight: var(
+		--wp--custom--superlist-block--typography--line-height,
+		inherit
+	);
+	--textTransform: var(
+		--wp--custom--superlist-block--typography--text-transform,
+		inherit
+	);
+	--fontWeight: var(
+		--wp--custom--superlist-block--typography--font-weight,
+		inherit
+	);
+
+	--margin: var(--wp--custom--superlist-block--spacing--margin, inherit);
+	--padding: var(--wp--custom--superlist-block--spacing--padding, inherit);
+	color: var(--textColor);
+	background-color: var(--backgroundColor);
+	font-size: var(--fontSize);
+	font-family: var(--fontFamily);
+	font-weight: var(--fontWeight);
+	line-height: var(--lineHeight);
+	text-transform: var(--textTransform);
+	margin: var(--margin);
+	padding: var(--padding);
+	a {
+		color: var(--linkColor);
+	}
 	&.horizontal {
 		display: grid;
 		gap: 2rem;

--- a/src/superlist/style.scss
+++ b/src/superlist/style.scss
@@ -5,7 +5,10 @@
  * Replace them with your own styles or remove the file completely.
  */
 .wp-block-createwithrani-superlist-block {
-	--listItemWidth: var(--wp--custom--superlist-block--item--width, 250px);
+	--listItemWidth: var(
+		--wp--custom--superlist-block--list-settings--width,
+		250px
+	);
 	--textColor: var(--wp--custom--superlist-block--color--text, inherit);
 	--linkColor: var(--wp--custom--superlist-block--color--link, inherit);
 	--backgroundColor: var(

--- a/theme.json
+++ b/theme.json
@@ -2,14 +2,41 @@
 	"custom": {
 		"superlist-block": {
 			"color": {
-				"text": "#115463"
+				"text": "#115463",
+				"link": "#115463",
+				"background": "#b2d38c"
 			},
 			"typography": {
-				"fontSize": "18px",
-				"fontFamily": "serif"
+				"fontSize": "25px",
+				"fontFamily": "serif",
+				"lineHeight": "1.5",
+				"textTransform": "uppercase",
+				"fontWeight": "700"
+			},
+			"spacing": {
+				"margin": "1.5rem",
+				"padding": "1rem"
 			},
 			"item": {
 				"width":"320px"
+			}
+		},
+		"superlist-item": {
+			"color": {
+				"text": "#115463",
+				"link": "#115463",
+				"background": "#b2d38c"
+			},
+			"typography": {
+				"fontSize": "35px",
+				"fontFamily": "serif",
+				"lineHeight": "1.5",
+				"textTransform": "uppercase",
+				"fontWeight": "700"
+			},
+			"spacing": {
+				"margin": "1.5rem",
+				"padding": "1rem"
 			}
 		}
 	}

--- a/theme.json
+++ b/theme.json
@@ -17,8 +17,9 @@
 				"margin": "1.5rem",
 				"padding": "1rem"
 			},
-			"item": {
-				"width":"320px"
+			"listSettings": {
+				"width":"320px",
+				"orientation": "horizontal"
 			}
 		},
 		"superlist-item": {

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,9 @@
+{
+	"custom": {
+		"superlist-block": {
+			"item": {
+				"width":"320px"
+			}
+		}
+	}
+}

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,13 @@
 {
 	"custom": {
 		"superlist-block": {
+			"color": {
+				"text": "#115463"
+			},
+			"typography": {
+				"fontSize": "18px",
+				"fontFamily": "serif"
+			},
 			"item": {
 				"width":"320px"
 			}


### PR DESCRIPTION
Closes #8 

This is a pretty awesome PR, even if I do say so myself. There are a few different things happening here:

- I've added link color support to both blocks
- the `list-item width` setting no longer sets explicit inline size, and rather modifies a CSS Custom Property inline instead
- there is `theme.json` support for not only the `list-item width` setting, but for all the settings the block supports, so any theme can set their own defaults for the Super List block.
  - this includes smart support for the orientation setting! if `theme.json` sets a default for the list `orientation`, it will be respected. So if a theme primarily wants to use Super List in horizontal mode, they can set that as their default so they don't keep having to switch it in every new block.
- we've also got a handy dandy theme.json example in the block itself to make life easier for theme authors 