### PR TITLE
Add `wp-env` config file

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,5 @@
+{
+	"core": "WordPress/WordPress",
+	"plugins": [ "./" ],
+	"port": 80
+}


### PR DESCRIPTION
Adds a super basic config file for using `wp-env` for development purposes.