### PR TITLE
Add a blueprint.json file for Live Preview support on WordPress.org

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -26,6 +26,11 @@
 		"step": "writeFile",
 		"path": "/wordpress/wp-content/mu-plugins/playground-notice.php",
 		"data": "<?php add_action( 'admin_notices', function() { echo '<div class=\"notice notice-info is-dismissible\"><p>This is a live preview of <strong>Super List Block</strong>, powered by <a href=\"https://wordpress.org/playground/\" target=\"_blank\">WordPress Playground</a>.</p></div>'; } );"
+	  },
+	  {
+		"step": "writeFile",
+		"path": "/wordpress/wp-content/mu-plugins/super-list-post.php",
+		"data": "<?php add_action( 'init', function() { wp_insert_post(array('post_title' => 'Super List Block','post_content' => '<!-- wp:createwithrani/superlist-block --><ul class=\"wp-block-createwithrani-superlist-block ul\"><!-- wp:createwithrani/superlist-item --><li class=\"wp-block-createwithrani-superlist-item\"><!-- wp:paragraph --><p>This is a super list block.</p><!-- /wp:paragraph --><!-- wp:heading {\"level\":3} --><h3 class=\"wp-block-heading\">I can add a heading in a list item</h3><!-- /wp:heading --><!-- wp:paragraph --><p>And then add more paragraphs</p><!-- /wp:paragraph --></li><!-- /wp:createwithrani/superlist-item --><!-- wp:createwithrani/superlist-item --><li class=\"wp-block-createwithrani-superlist-item\"><!-- wp:paragraph --><p>This is another super list item</p><!-- /wp:paragraph --></li><!-- /wp:createwithrani/superlist-item --></ul><!-- /wp:createwithrani/superlist-block -->','post_status' => 'publish','post_type' => 'post','post_author' => 1,'post_excerpt' => 'This is a live preview of Super List Block, powered by WordPress Playground.',));} );"
 	  }
 	]
   }

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,31 @@
+{
+	"landingPage": "/wp-admin/post.php?post=4&action=edit",
+	"phpExtensionBundles": [
+	  "kitchen-sink"
+	],
+	"features": {
+	  "networking": true
+	},
+	"steps": [
+	  {
+		"step": "login",
+		"username": "admin",
+		"password": "password"
+	  },
+	  {
+		"step": "installPlugin",
+		"pluginData": {
+		  "resource": "wordpress.org/plugins",
+		  "slug": "superlist-block"
+		},
+		"options": {
+		  "activate": true
+		}
+	  },
+	  {
+		"step": "writeFile",
+		"path": "/wordpress/wp-content/mu-plugins/playground-notice.php",
+		"data": "<?php add_action( 'admin_notices', function() { echo '<div class=\"notice notice-info is-dismissible\"><p>This is a live preview of <strong>Super List Block</strong>, powered by <a href=\"https://wordpress.org/playground/\" target=\"_blank\">WordPress Playground</a>.</p></div>'; } );"
+	  }
+	]
+  }


### PR DESCRIPTION
Closes #53 

This pull request involves adding a new blueprint configuration for WordPress. The configuration sets up a specific environment with predefined steps to enhance the user experience by automating certain tasks.

Key changes include:

* [`.wordpress-org/blueprints/blueprint.json`](diffhunk://#diff-0c8e8cdc6acb984680b26ee496aafb533f79c7a7f37f1b4905e84dca0f625863R1-R36): Added a new blueprint configuration that includes a landing page URL, PHP extension bundles, and features. It also defines several steps such as user login, plugin installation, and writing specific files to the WordPress content directory.
* The blueprint creates a new post and loads it in the Playground with a sample super list block in the editor.