### PR TITLE
Fix the ability to add list items.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"packages-update": "wp-scripts packages-update",
 		"plugin-zip": "wp-scripts plugin-zip",
-		"start": "wp-scripts start",
+		"start": "wp-env start && wp-scripts start",
 		"test:e2e": "wp-scripts test-e2e",
-		"test:unit": "wp-scripts test-unit-js"
+		"test:unit": "wp-scripts test-unit-js",
+		"stop": "wp-env stop"
 	},
 	"dependencies": {
 		"@wordpress/block-editor": "^8.0.11",

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Super List Block ===
 Contributors:      aurooba, cr0ybot
 Tags:              block, list, nesting, repeater, superlist
-Requires at least: 5.9
+Requires at least: 6.3
 Tested up to:      6.7.2
 Requires PHP:      7.0
 Stable tag:        0.1.3

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags:              block, list, nesting, repeater, superlist
 Requires at least: 6.3
 Tested up to:      6.7.2
 Requires PHP:      7.0
-Stable tag:        0.1.3
+Stable tag:        0.1.4
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Donate link:       https://github.com/sponsors/aurooba

--- a/src/superlist-item/block.json
+++ b/src/superlist-item/block.json
@@ -1,14 +1,14 @@
 {
 	"$schema": "https://json.schemastore.org/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "createwithrani/superlist-item",
-	"parent": [
-		"createwithrani/superlist"
-	],
-	"version": "0.1.1",
+	"version": "0.1.3",
 	"title": "Super List Item",
 	"category": "design",
 	"description": "A list item that allows you to nest as many other blocks as you like inside it.",
+	"parent": [
+		"createwithrani/superlist-block"
+	],
 	"supports": {
 		"anchor": true,
 		"html": true,
@@ -30,6 +30,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
+			"textAlign": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/src/superlist-item/editor.scss
+++ b/src/superlist-item/editor.scss
@@ -5,9 +5,6 @@
  */
 
 [data-type="createwithrani/superlist-block"] {
-	.block-editor-inserter {
-		display: flex;
-	}
 	.block-list-appender {
 		button.block-list-appender__toggle {
 			width: auto;

--- a/src/superlist/block.json
+++ b/src/superlist/block.json
@@ -1,11 +1,12 @@
 {
 	"$schema": "https://json.schemastore.org/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "createwithrani/superlist-block",
-	"version": "0.1.1",
+	"version": "0.1.3",
 	"title": "Super List",
 	"category": "design",
 	"description": "Nest multiple blocks inside list items in any kind of list (ordered, unordered, no marker, etc)",
+	"allowedBlocks": ["createwithrani/superlist-item"],
 	"attributes": {
 		"listStyle":{
 			"type": "string",

--- a/src/superlist/edit/edit.js
+++ b/src/superlist/edit/edit.js
@@ -21,7 +21,7 @@ import {
 	BlockControls,
 	useInnerBlocksProps,
 	InspectorControls,
-	useSetting,
+	useSettings,
 	BlockVerticalAlignmentToolbar,
 } from "@wordpress/block-editor";
 import {
@@ -50,7 +50,6 @@ import "./editor.scss";
 const ALLOWED_BLOCKS = ["createwithrani/superlist-item"];
 const LIST_TEMPLATE = [
 	["createwithrani/superlist-item"],
-	["createwithrani/superlist-item"],
 ];
 
 /**
@@ -65,7 +64,7 @@ export default function Edit({ attributes, setAttributes }) {
 	const { listStyle, orientation, itemWidth, verticalAlignment } = attributes;
 
 	// check if theme.json has set a preferred list orientation
-	const themeListOrientation = useSetting(
+	const [themeListOrientation] = useSettings(
 		"custom.superlist-block.listSettings.orientation"
 	);
 

--- a/src/superlist/index.js
+++ b/src/superlist/index.js
@@ -39,5 +39,5 @@ registerBlockType("createwithrani/superlist-block", {
 	edit,
 	save,
 	example,
-	transforms,
+	// transforms,
 });

--- a/superlist-block.php
+++ b/superlist-block.php
@@ -18,6 +18,8 @@ if (! defined('SUPERLIST_BLOCK_PLUGIN_FILE') ) {
     define('SUPERLIST_BLOCK_PLUGIN_FILE', __FILE__);
 }
 
+add_action('init', 'create_block_superlist_block_block_init');
+
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued

--- a/superlist-block.php
+++ b/superlist-block.php
@@ -4,7 +4,7 @@
  * Description:       Nest multiple blocks inside lists of any kind of list (ordered, unordered, no marker, etc), or do away with list markers and use it like a repeater!
  * Requires at least: 5.9
  * Requires PHP:      7.0
- * Version:           0.1.3
+ * Version:           0.1.4
  * Author:            Aurooba Ahmed
  * Author URI:        https://aurooba.com
  * License:           GPL-2.0-or-later
@@ -33,4 +33,4 @@ function create_block_superlist_block_block_init()
     // Load available translations.
     wp_set_script_translations('createwithrani-superlist-block-editor-script-js', 'superlist-block');
 }
-add_action('init', 'create_block_superlist_block_block_init');
+


### PR DESCRIPTION
Bring back the very necessary ability to add more list items to the block. 

This pull request introduces several updates and improvements to the Super List Block plugin, including enhancements to block functionality, updates to compatibility requirements, and code refactoring for better maintainability. The most significant changes include updating the block API version, improving block insertion logic, and introducing new features for parent-child block relationships.

### Block functionality updates:

* Updated `block.json` files for `superlist-item` and `superlist-block` to use `apiVersion: 3`, added `allowedBlocks` for `superlist-block`, and adjusted the `parent` property for `superlist-item` to reference `superlist-block`. These changes enhance compatibility with the latest WordPress block editor APIs. [[1]](diffhunk://#diff-47b15c512fb2f3bd5419ecde7a4524a192af0eb010c0f113cee16e73ade79204L3-R11) [[2]](diffhunk://#diff-bc0777dd60250fd16c991ee6f60bd40f7d4449d1463925a6e25eb8df335b28cdL3-R9)
* Added `textAlign` support to the `supports` section of `superlist-item/block.json`, enabling text alignment customization.

### Code refactoring:

* Refactored `Edit` function in `src/superlist-item/edit.js` to improve block insertion logic by simplifying parent block retrieval and enhancing the `insertListItem` function. This ensures more reliable handling of parent-child relationships. [[1]](diffhunk://#diff-9744a2b5de032f7024f0cdbcef7b71b5dfa81314542adfae87b9682b7973bb59L23-R23) [[2]](diffhunk://#diff-9744a2b5de032f7024f0cdbcef7b71b5dfa81314542adfae87b9682b7973bb59L45-R96)
* Replaced `useSetting` with `useSettings` in `src/superlist/edit/edit.js` for retrieving theme-specific settings, aligning with updated WordPress APIs. [[1]](diffhunk://#diff-492859f2158329117e92a87e0aefdcbc80f9a87ac0a5e47bfb508c2b3d28aabaL24-R24) [[2]](diffhunk://#diff-492859f2158329117e92a87e0aefdcbc80f9a87ac0a5e47bfb508c2b3d28aabaL68-R67)

### Compatibility and version updates:

* Increased the minimum WordPress version requirement to 6.3 and updated the stable tag to `0.1.4` in `readme.txt` and `superlist-block.php`. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L4-R7) [[2]](diffhunk://#diff-18eaaf378165a41d80cb1a0773f3ad8403cfadc55556ae588cb03e76caa10c74L7-R7)
* Registered the block initialization function earlier in `superlist-block.php` to ensure proper setup during the `init` hook. [[1]](diffhunk://#diff-18eaaf378165a41d80cb1a0773f3ad8403cfadc55556ae588cb03e76caa10c74R21-R22) [[2]](diffhunk://#diff-18eaaf378165a41d80cb1a0773f3ad8403cfadc55556ae588cb03e76caa10c74L36-R38)

### Miscellaneous:

* Added a new `stop` script to `package.json` for stopping the local WordPress environment.
* Removed redundant styles in `src/superlist-item/editor.scss` to clean up unused CSS.