### PR TITLE
When there is no marker, the list type should be ul not ol

### DIFF
--- a/src/superlist/edit/edit.js
+++ b/src/superlist/edit/edit.js
@@ -141,7 +141,7 @@ export default function Edit({ attributes, setAttributes }) {
 	/**
 	 * Set container tag name based on list style, if the list style is none, set it to `ol`
 	 */
-	const ListContainer = "none" !== listStyle ? listStyle : "ol";
+	const ListContainer = "none" !== listStyle ? listStyle : "ul";
 
 	return (
 		<>

--- a/src/superlist/save.js
+++ b/src/superlist/save.js
@@ -31,7 +31,7 @@ export default function save({ attributes }) {
 	const subItemWidth = {
 		gridTemplateColumns: `repeat(auto-fill, minmax(${itemWidth}, 1fr))`,
 	};
-	const ListContainer = "none" !== listStyle ? listStyle : "ol";
+	const ListContainer = "none" !== listStyle ? listStyle : "ul";
 	return (
 		<ListContainer
 			{...useBlockProps.save({


### PR DESCRIPTION
This pull request updates the default list container element for cases where the list style is set to "none." The changes ensure consistency by using an unordered list (`ul`) instead of an ordered list (`ol`) in such scenarios.

Updates to list container logic:

* [`src/superlist/edit/edit.js`](diffhunk://#diff-492859f2158329117e92a87e0aefdcbc80f9a87ac0a5e47bfb508c2b3d28aabaL144-R144): Changed the default `ListContainer` to `ul` when the `listStyle` is "none" in the `Edit` component.
* [`src/superlist/save.js`](diffhunk://#diff-1521457cfc548eba36ab569d395648675f541a5e008d1985962caeda838fe8ffL34-R34): Updated the default `ListContainer` to `ul` when the `listStyle` is "none" in the `save` function.